### PR TITLE
Reward distribution timeline update

### DIFF
--- a/contracts/interfaces/rewards/IEmissionManager.sol
+++ b/contracts/interfaces/rewards/IEmissionManager.sol
@@ -10,12 +10,6 @@ import "./IRewardsController.sol";
 interface IEmissionManager {
     error NotEmissionAdmin(address sender, address reward);
 
-    error CarbonRewardDistributionOutOfSync(
-        uint lastCarbonRewardDistributionTimestamp,
-        uint redistributionTimestamp
-    );
-    error CarbonRewardDistributionNotStarted();
-
     /// @dev Emitted when the admin of a reward emission is updated.
     /// @param reward The address of the rewarding token
     /// @param oldAdmin The address of the old emission admin
@@ -96,11 +90,6 @@ interface IEmissionManager {
     /// @dev Only callable by the owner of the EmissionManager
     /// @param controller the address of the RewardsController contract
     function setRewardsController(address controller) external;
-
-    /// @dev Only callable by the owner of the EmissionManager
-    /// @param carbonRewardDistributionTimestamp The timestamp of the carbon reward distribution
-    function setCarbonRewardDistributionTimestamp(uint32 carbonRewardDistributionTimestamp)
-        external;
 
     /// @dev Returns the rewards controller address
     /// @return The address of the RewardsController contract

--- a/contracts/interfaces/rewards/IRewardsDistributor.sol
+++ b/contracts/interfaces/rewards/IRewardsDistributor.sol
@@ -55,7 +55,7 @@ interface IRewardsDistributor {
 
     /// @param asset The address of the incentivized asset
     /// @param reward The address of the reward token
-    error UpdateOngoingRewardDistribution(address asset, address reward);
+    error UpdateDistributionNotApplicable(address asset, address reward);
 
     /// @dev Sets the end date for the distribution
     /// @param asset The asset to incentivize
@@ -81,18 +81,19 @@ interface IRewardsDistributor {
     /// @param assets List of incentivized assets getting updated
     /// @param rewards List of reward tokens getting updated
     /// @param rewardAmounts List of carbon reward amounts getting distributed
-    /// @param newDistributionEnd The end date of the incentivization, in unix time format
-    function updateRewardDistribution(
+    function updateCarbonRewardDistribution(
         address[] calldata assets,
         address[] calldata rewards,
-        uint[] calldata rewardAmounts,
-        uint32 newDistributionEnd
+        uint[] calldata rewardAmounts
     ) external;
 
     /// @param asset The incentivized asset
     /// @param reward The reward token of the incentivized asset
-    /// @return true, if rewards are still being distributed for the asset - reward pair
-    function isOngoingDistribution(address asset, address reward) external view returns (bool);
+    /// @return true, if distribution can be updated for the asset - reward pair
+    function canUpdateCarbonRewardDistribution(address asset, address reward)
+        external
+        view
+        returns (bool);
 
     /// @dev Gets the end date for the distribution
     /// @param asset The incentivized asset

--- a/contracts/rewards/RewardsDistributor.sol
+++ b/contracts/rewards/RewardsDistributor.sol
@@ -200,26 +200,28 @@ abstract contract RewardsDistributor is IRewardsDistributor {
     }
 
     /// @inheritdoc IRewardsDistributor
-    function updateRewardDistribution(
+    function updateCarbonRewardDistribution(
         address[] calldata assets,
         address[] calldata rewards,
-        uint[] calldata rewardAmounts,
-        uint32 newDistributionEnd
+        uint[] calldata rewardAmounts
     ) external override onlyEmissionManager {
         if (assets.length != rewards.length || rewards.length != rewardAmounts.length) {
             revert InvalidInput();
         }
 
-        assert(newDistributionEnd > block.timestamp);
-
         for (uint i; i < assets.length; i++) {
-            if (_isOngoingDistribution(assets[i], rewards[i])) {
-                revert UpdateOngoingRewardDistribution(assets[i], rewards[i]);
+            if (!_canUpdateCarbonRewardDistribution(assets[i], rewards[i])) {
+                revert UpdateDistributionNotApplicable(assets[i], rewards[i]);
             }
 
+            uint32 newDistributionEnd = _computeNewCarbonRewardDistributionEnd(
+                assets[i],
+                rewards[i]
+            );
             uint88 newEmissionsPerSecond = uint88(
                 rewardAmounts[i] / (newDistributionEnd - block.timestamp)
             );
+
             (uint oldEmissionPerSecond, uint newIndex, ) = _setEmissionPerSecond(
                 assets[i],
                 rewards[i],
@@ -258,12 +260,37 @@ abstract contract RewardsDistributor is IRewardsDistributor {
     }
 
     /// @inheritdoc IRewardsDistributor
-    function isOngoingDistribution(address asset, address reward) external view returns (bool) {
-        return _isOngoingDistribution(asset, reward);
+    function canUpdateCarbonRewardDistribution(address asset, address reward)
+        external
+        view
+        returns (bool)
+    {
+        return _canUpdateCarbonRewardDistribution(asset, reward);
     }
 
-    function _isOngoingDistribution(address asset, address reward) internal view returns (bool) {
-        return _assets[asset].rewards[reward].distributionEnd > block.timestamp;
+    function _canUpdateCarbonRewardDistribution(address asset, address reward)
+        internal
+        view
+        returns (bool)
+    {
+        uint32 currentDistributionEnd = _assets[asset].rewards[reward].distributionEnd;
+        uint32 nextDistributionEnd = _computeNewCarbonRewardDistributionEnd(asset, reward);
+
+        bool isInitializedDistribution = currentDistributionEnd != 0;
+        bool isBetweenDistributions = block.timestamp >= currentDistributionEnd &&
+            block.timestamp < nextDistributionEnd;
+
+        return isInitializedDistribution && isBetweenDistributions;
+    }
+
+    function _computeNewCarbonRewardDistributionEnd(address asset, address reward)
+        internal
+        view
+        returns (uint32 newDistributionEnd)
+    {
+        uint32 currentDistributionEnd = _assets[asset].rewards[reward].distributionEnd;
+
+        newDistributionEnd = currentDistributionEnd + 1 weeks;
     }
 
     /// @dev Configure the _assets for a specific emission


### PR DESCRIPTION
Closes #171 

* ~~Introduce previous distribution end in EmissionManager~~
* RewardsDistributor throttles emissionPerSecond w/r/t time until distributionEnd
* encapsulate distributionEnd updates inside RewardsDistributor
* local distributionEnd updates per carbon reward

Updated diagrams:
https://www.figma.com/file/gJH5utH2egxaHqMCW19N76/Architecture-%2F-Flow-diagrams?node-id=97%3A643&t=fVDZ9hbzjGuwYUoG-4
https://www.figma.com/file/gJH5utH2egxaHqMCW19N76/Architecture-%2F-Flow-diagrams?node-id=55%3A584&t=fVDZ9hbzjGuwYUoG-4