### PR TITLE
Remove foundry network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ node_modules
 /artifacts
 /cache
 /deployments/localhost
-/deployments/foundry
 
 # Foundry outputs and cache
 /out

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ OPTIONS:
 ▶ Deploying ERC-20 tokens with hardhat
 
 ```shell
-yarn hardhat deploy-erc20 --network foundry --quantity 3 --owner 0xabcde
+yarn hardhat deploy-erc20 --network localhost --quantity 3 --owner 0xabcde
 ```
 
-This command deploys 3 ERC-20 tokens on the Foundry network, owned by the address 0xabcde.
+This command deploys 3 ERC-20 tokens on the localhost network, owned by the address 0xabcde.
 
 - `--quantity` flag specifies the number of tokens to deploy (Default: 1)
 - `--owner` flag specifies the owner of the tokens (Default: OWNER_ADDRESS)

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -68,10 +68,6 @@ module.exports = {
     localhost: {
       url: 'http://127.0.0.1:8545',
       timeout: 10000
-    },
-    foundry: {
-      url: 'http://127.0.0.1:8545',
-      timeout: 10000
     }
   },
   etherscan: {

--- a/tasks/deploy-reward-oracle.js
+++ b/tasks/deploy-reward-oracle.js
@@ -93,5 +93,5 @@ task('deploy-reward-oracle', 'Deploys a reward price oracle contract')
   )
 
 function isLocalhost(networkName) {
-  return ['localhost', 'foundry'].includes(networkName)
+  return ['localhost'].includes(networkName)
 }


### PR DESCRIPTION
PR makes the network setup simpler by removing the "foundry" network. We no longer need it, as we can use one network for both development and testing, and deploy contracts accordingly. 