### PR TITLE
Sketch simulate zap staking

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ The following tasks are available in Hardhat:
     - `--quantity`: The number of tokens to deploy (Default: 1).
     - `--owner`: The owner of the tokens (Default: OWNER_ADDRESS).
 
+4. Deploy a new SolidZapStaker contract:
+   ```shell
+   yarn hardhat --network localhost deploy-zap-staker [OPTIONS]
+   ```
+
+   Options:
+   - `--router`: The address of the router used to perform token swaps.
+   - `--uni-proxy`: The address of the Gamma UniProxy contract used for deploying liquidity.
+   - `--solid-staking`: The address of our SolidStaking contract, to stake with recipient.
+
 ## Upgradable Contracts
 
 The following contracts are upgradable and managed by a `DefaultProxyAdmin` contract. The owner of the `DefaultProxyAdmin` contract is authorized to upgrade both contracts.

--- a/contracts/interfaces/staking/ISolidZapStaker.sol
+++ b/contracts/interfaces/staking/ISolidZapStaker.sol
@@ -83,7 +83,7 @@ interface ISolidZapStaker {
     /// @param hypervisor The hypervisor used to deploy liquidity
     /// @param swap1 Encoded swap to partially swap `inputToken` to desired token
     /// @param swap2 Encoded swap to partially swap `inputToken` to desired token
-    /// @return dustless Whether the resulting tokens qualify for a dustless liquidity deployment
+    /// @return isDustless Whether the resulting tokens qualify for a dustless liquidity deployment
     /// @return shares The amount of shares minted from the dustless liquidity deployment
     /// @return ratio The current gamma token ratio, or empty if dustless
     function simulateStakeDoubleSwap(
@@ -95,7 +95,7 @@ interface ISolidZapStaker {
     )
         external
         returns (
-            bool dustless,
+            bool isDustless,
             uint shares,
             Fraction memory ratio
         );

--- a/contracts/interfaces/staking/ISolidZapStaker.sol
+++ b/contracts/interfaces/staking/ISolidZapStaker.sol
@@ -37,7 +37,7 @@ interface ISolidZapStaker {
     /// @param swap2 Encoded swap to partially swap `inputToken` to desired token
     /// @param minShares The minimum amount of liquidity shares required for transaction to succeed
     /// @param recipient The beneficiary of the staked shares
-    /// @return The amount of shares staked in `solidStaking`
+    /// @return shares The amount of shares staked in `solidStaking`
     function stakeDoubleSwap(
         address inputToken,
         uint inputAmount,
@@ -46,7 +46,7 @@ interface ISolidZapStaker {
         bytes calldata swap2,
         uint minShares,
         address recipient
-    ) external returns (uint);
+    ) external returns (uint shares);
 
     /// @notice Zap function that achieves the following:
     /// 1. Partially swaps `inputToken` to desired token via encoded swap1
@@ -60,7 +60,7 @@ interface ISolidZapStaker {
     /// @param swap1 Encoded swap to partially swap `inputToken` to desired token
     /// @param swap2 Encoded swap to partially swap `inputToken` to desired token
     /// @param minShares The minimum amount of liquidity shares required for transaction to succeed
-    /// @return The amount of shares staked in `solidStaking`
+    /// @return shares The amount of shares staked in `solidStaking`
     function stakeDoubleSwap(
         address inputToken,
         uint inputAmount,
@@ -68,7 +68,7 @@ interface ISolidZapStaker {
         bytes calldata swap1,
         bytes calldata swap2,
         uint minShares
-    ) external returns (uint);
+    ) external returns (uint shares);
 
     /// @notice Function is meant to be called off-chain with _staticCall_.
     /// @notice Zap function that achieves the following:

--- a/contracts/interfaces/staking/ISolidZapStaker.sol
+++ b/contracts/interfaces/staking/ISolidZapStaker.sol
@@ -20,6 +20,8 @@ interface ISolidZapStaker {
 
     function router() external view returns (address);
 
+    function weth() external view returns (address);
+
     function iUniProxy() external view returns (address);
 
     function solidStaking() external view returns (address);

--- a/contracts/interfaces/staking/ISolidZapStaker.sol
+++ b/contracts/interfaces/staking/ISolidZapStaker.sol
@@ -72,6 +72,46 @@ interface ISolidZapStaker {
         uint minShares
     ) external returns (uint shares);
 
+    /// @notice Zap function that achieves the following:
+    /// 1. Wraps `msg.value` to WETH
+    /// 2. Partially swaps `WETH` to desired token via encoded swap1
+    /// 3. Partially swaps `WETH` to desired token via encoded swap2
+    /// 4. Resulting tokens are deployed as liquidity via IUniProxy & `hypervisor`
+    /// 5. Shares of the deployed liquidity are staked in `solidStaking`. `recipient` is the beneficiary of the staked shares
+    /// @notice The msg.sender must own `inputAmount` and approve this contract to spend `WETH`
+    /// @param hypervisor The hypervisor used to deploy liquidity
+    /// @param swap1 Encoded swap to partially swap `WETH` to desired token
+    /// @param swap2 Encoded swap to partially swap `WETH` to desired token
+    /// @param minShares The minimum amount of liquidity shares required for transaction to succeed
+    /// @param recipient The beneficiary of the staked shares
+    /// @return shares The amount of shares staked in `solidStaking`
+    function stakeETH(
+        address hypervisor,
+        bytes calldata swap1,
+        bytes calldata swap2,
+        uint minShares,
+        address recipient
+    ) external payable returns (uint shares);
+
+    /// @notice Zap function that achieves the following:
+    /// 1. Wraps `msg.value` to WETH
+    /// 2. Partially swaps `WETH` to desired token via encoded swap1
+    /// 3. Partially swaps `WETH` to desired token via encoded swap2
+    /// 4. Resulting tokens are deployed as liquidity via IUniProxy & `hypervisor`
+    /// 5. Shares of the deployed liquidity are staked in `solidStaking`. `msg.sender` is the beneficiary of the staked shares
+    /// @notice The msg.sender must own `inputAmount` and approve this contract to spend `WETH`
+    /// @param hypervisor The hypervisor used to deploy liquidity
+    /// @param swap1 Encoded swap to partially swap `WETH` to desired token
+    /// @param swap2 Encoded swap to partially swap `WETH` to desired token
+    /// @param minShares The minimum amount of liquidity shares required for transaction to succeed
+    /// @return shares The amount of shares staked in `solidStaking`
+    function stakeETH(
+        address hypervisor,
+        bytes calldata swap1,
+        bytes calldata swap2,
+        uint minShares
+    ) external payable returns (uint shares);
+
     /// @notice Function is meant to be called off-chain with _staticCall_.
     /// @notice Zap function that achieves the following:
     /// 1. Partially swaps `inputToken` to desired token via encoded swap1

--- a/contracts/interfaces/staking/IWETH.sol
+++ b/contracts/interfaces/staking/IWETH.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.16;
+
+interface IWETH {
+    function deposit() external payable;
+
+    function withdraw(uint amount) external;
+}

--- a/contracts/interfaces/staking/IWETH.sol
+++ b/contracts/interfaces/staking/IWETH.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.16;
 interface IWETH {
     function deposit() external payable;
 
-    function withdraw(uint amount) external;
+    function approve(address spender, uint amount) external returns (bool);
 }

--- a/contracts/zap/staking/SolidZapStaker.sol
+++ b/contracts/zap/staking/SolidZapStaker.sol
@@ -39,6 +39,8 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
         weth = _weth;
         iUniProxy = _iUniProxy;
         solidStaking = _solidStaking;
+
+        IWETH(weth).approve(_router, type(uint).max);
     }
 
     /// @inheritdoc ISolidZapStaker

--- a/contracts/zap/staking/SolidZapStaker.sol
+++ b/contracts/zap/staking/SolidZapStaker.sol
@@ -14,6 +14,7 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
     using GPv2SafeERC20 for IERC20;
 
     address public immutable router;
+    address public immutable weth;
     address public immutable iUniProxy;
     address public immutable solidStaking;
 
@@ -29,10 +30,12 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
 
     constructor(
         address _router,
+        address _weth,
         address _iUniProxy,
         address _solidStaking
     ) {
         router = _router;
+        weth = _weth;
         iUniProxy = _iUniProxy;
         solidStaking = _solidStaking;
     }

--- a/contracts/zap/staking/SolidZapStaker.sol
+++ b/contracts/zap/staking/SolidZapStaker.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../interfaces/staking/ISolidZapStaker.sol";
 import "../../interfaces/staking/ISolidStakingActions_0_8_18.sol";
+import "../../interfaces/staking/IWETH.sol";
 import "../../interfaces/liquidity-deployer/IHypervisor_0_8_18.sol";
 import "../../interfaces/liquidity-deployer/IUniProxy_0_8_18.sol";
 import "../../libraries/GPv2SafeERC20_0_8_18.sol";
@@ -63,6 +64,29 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
         uint minShares
     ) external nonReentrant returns (uint) {
         return _stakeDoubleSwap(inputToken, inputAmount, hypervisor, swap1, swap2, minShares, msg.sender);
+    }
+
+    function stakeETH(
+        address hypervisor,
+        bytes calldata swap1,
+        bytes calldata swap2,
+        uint minShares,
+        address recipient
+    ) external payable returns (uint) {
+        _wrap(msg.value);
+
+        return 0;
+    }
+
+    function stakeETH(
+        address hypervisor,
+        bytes calldata swap1,
+        bytes calldata swap2,
+        uint minShares
+    ) external payable returns (uint) {
+        _wrap(msg.value);
+
+        return 0;
     }
 
     /// @inheritdoc ISolidZapStaker
@@ -178,6 +202,10 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
         if (!success) {
             _propagateError(retData);
         }
+    }
+
+    function _wrap(uint amount) private {
+        IWETH(weth).deposit{ value: amount }();
     }
 
     function _fetchHypervisorTokens(address hypervisor)

--- a/contracts/zap/staking/SolidZapStaker.sol
+++ b/contracts/zap/staking/SolidZapStaker.sol
@@ -84,6 +84,14 @@ contract SolidZapStaker is ISolidZapStaker, ReentrancyGuard {
         HypervisorTokens memory tokens = _fetchHypervisorTokens(hypervisor);
         TokenBalances memory acquiredTokenAmounts = _executeSwapsAndReturnResult(swap1, swap2, tokens);
         (isDustless, ratio) = _isDustless(hypervisor, tokens.token0, acquiredTokenAmounts);
+
+        if (isDustless) {
+            shares = _deployLiquidity(
+                acquiredTokenAmounts.token0Balance,
+                acquiredTokenAmounts.token1Balance,
+                hypervisor
+            );
+        }
     }
 
     function _isDustless(

--- a/tasks/deploy-zap-staker.js
+++ b/tasks/deploy-zap-staker.js
@@ -1,0 +1,48 @@
+const { initializeGasStation } = require('@solid-world/gas-station')
+
+task('deploy-zap-staker', 'Deploys a SolidZapStaker contract')
+  .addParam('router', 'The address of the router used to perform token swaps.')
+  .addParam(
+    'uniProxy',
+    'The address of the Gamma UniProxy contract used for deploying liquidity.'
+  )
+  .addParam(
+    'solidStaking',
+    'The address of our SolidStaking contract, to stake with recipient.'
+  )
+  .setAction(
+    async (
+      { router, uniProxy, solidStaking },
+      { getNamedAccounts, deployments, ethers }
+    ) => {
+      const gasStation = await initializeGasStation(ethers.provider)
+      const { deployer } = await getNamedAccounts()
+
+      const deploymentName = await makeDeploymentName(
+        router,
+        uniProxy,
+        solidStaking
+      )
+      const SolidZapStaker = await deployments.deploy(deploymentName, {
+        ...(await gasStation.getCurrentFees()),
+        contract: 'SolidZapStaker',
+        from: deployer,
+        args: [router, uniProxy, solidStaking],
+        log: true
+      })
+
+      console.log(`SolidZapStaker address: ${SolidZapStaker.address}`)
+    }
+  )
+
+async function makeDeploymentName(router, uniProxy, solidStaking) {
+  router = last4Digits(router)
+  uniProxy = last4Digits(uniProxy)
+  solidStaking = last4Digits(solidStaking)
+
+  return `SolidZapStaker_${router}_${uniProxy}_${solidStaking}`
+}
+
+function last4Digits(address) {
+  return address.slice(-4)
+}

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,5 +1,6 @@
 exports.deployErc20 = require('./deploy-erc20')
 exports.deployRewardOracle = require('./deploy-reward-oracle')
 exports.deployLiquidityDeployer = require('./deploy-liquidity-deployer')
+exports.deployZapStaker = require('./deploy-zap-staker')
 exports.upgradeSwm = require('./upgrade-swm')
 exports.upgradeVerificationRegistry = require('./upgrade-verification-registry')

--- a/test/zap/staking/BaseSolidZapStaker.t.sol
+++ b/test/zap/staking/BaseSolidZapStaker.t.sol
@@ -9,6 +9,7 @@ import "../../../contracts/interfaces/liquidity-deployer/IUniProxy_0_8_18.sol";
 import "../../liquidity-deployer/TestToken.sol";
 import "./MockRouter.sol";
 import "./RouterBehaviour.sol";
+import "./WMATIC.sol";
 
 abstract contract BaseSolidZapStaker is BaseTest {
     address public ROUTER;
@@ -20,6 +21,7 @@ abstract contract BaseSolidZapStaker is BaseTest {
     TestToken public hypervisor;
     TestToken public token0;
     TestToken public token1;
+    WMATIC public weth;
 
     bytes public emptySwap1;
     bytes public emptySwap2;
@@ -45,9 +47,10 @@ abstract contract BaseSolidZapStaker is BaseTest {
         hypervisor = new TestToken("Hypervisor", "LP", 18);
         token0 = new TestToken("USDC", "USDC", 6);
         token1 = new TestToken("CRISP SCORED MANGROVES", "CRISP-M", 18);
+        weth = new WMATIC();
         ROUTER = address(new MockRouter(address(token0), address(token1)));
 
-        zapStaker = new SolidZapStaker(ROUTER, IUNIPROXY, SOLIDSTAKING);
+        zapStaker = new SolidZapStaker(ROUTER, address(weth), IUNIPROXY, SOLIDSTAKING);
 
         _labelAccounts();
         _prepareZap();
@@ -182,6 +185,7 @@ abstract contract BaseSolidZapStaker is BaseTest {
 
     function _labelAccounts() private {
         vm.label(ROUTER, "Router");
+        vm.label(address(weth), "WETH");
         vm.label(IUNIPROXY, "IUniProxy");
         vm.label(SOLIDSTAKING, "SolidStaking");
         vm.label(testAccount0, "TestAccount0");

--- a/test/zap/staking/BaseSolidZapStaker.t.sol
+++ b/test/zap/staking/BaseSolidZapStaker.t.sol
@@ -95,6 +95,17 @@ abstract contract BaseSolidZapStaker is BaseTest {
         );
     }
 
+    function _expectCall_getDepositAmount(
+        address pos,
+        address token,
+        uint depositAmount
+    ) internal {
+        vm.expectCall(
+            IUNIPROXY,
+            abi.encodeWithSelector(IUniProxy.getDepositAmount.selector, pos, token, depositAmount)
+        );
+    }
+
     function _expectCall_stake(
         address token,
         uint amount,
@@ -140,6 +151,14 @@ abstract contract BaseSolidZapStaker is BaseTest {
         vm.mockCall(IUNIPROXY, abi.encodeWithSelector(IUniProxy.deposit.selector), abi.encode(sharesMinted));
     }
 
+    function _mockUniProxy_getDepositAmount(uint amountOut) internal {
+        vm.mockCall(
+            IUNIPROXY,
+            abi.encodeWithSelector(IUniProxy.getDepositAmount.selector),
+            abi.encode(amountOut - 10, amountOut + 10) // +/- 10 to account for average
+        );
+    }
+
     function _setBalancesBeforeSwap(uint token0BalanceBeforeSwap, uint token1BalanceBeforeSwap) internal {
         token0.mint(address(zapStaker), token0BalanceBeforeSwap);
         token1.mint(address(zapStaker), token1BalanceBeforeSwap);
@@ -180,6 +199,7 @@ abstract contract BaseSolidZapStaker is BaseTest {
         _mockHypervisor_token0();
         _mockHypervisor_token1();
         _mockUniProxy_deposit(0);
+        _mockUniProxy_getDepositAmount(10);
         _mockSolidStaking_stake();
     }
 }

--- a/test/zap/staking/BaseSolidZapStaker.t.sol
+++ b/test/zap/staking/BaseSolidZapStaker.t.sol
@@ -95,6 +95,10 @@ abstract contract BaseSolidZapStaker is BaseTest {
         );
     }
 
+    function _doNotExpectCall_deposit() internal {
+        vm.expectCall(IUNIPROXY, abi.encodeWithSelector(IUniProxy.deposit.selector), 0);
+    }
+
     function _expectCall_getDepositAmount(
         address pos,
         address token,

--- a/test/zap/staking/RouterBehaviour.sol
+++ b/test/zap/staking/RouterBehaviour.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity 0.8.18;
 
 enum RouterBehaviour {
     MINTS_TOKEN0,

--- a/test/zap/staking/SimulateStakeDoubleSwap.t.sol
+++ b/test/zap/staking/SimulateStakeDoubleSwap.t.sol
@@ -142,4 +142,23 @@ contract SimulateStakeDoubleSwapTest is BaseSolidZapStaker {
         assertEq(actualRatio.numerator, 0);
         assertEq(actualRatio.denominator, 0);
     }
+
+    function testSimulateStakeDoubleSwap_ifNotDustless_doesNotDeployLiquidityAndReturnsCurrentRatio() public {
+        uint token0AcquiredFromSwap = 500;
+        uint token1AcquiredFromSwap = 600;
+        uint token1DustlessAmount = 800;
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, token0AcquiredFromSwap);
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, token1AcquiredFromSwap);
+
+        vm.prank(testAccount0);
+        _mockUniProxy_getDepositAmount(token1DustlessAmount);
+        _doNotExpectCall_deposit();
+        (bool actualIsDustless, uint actualShares, ISolidZapStaker.Fraction memory actualRatio) = zapStaker
+            .simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, swap2);
+
+        assertEq(actualIsDustless, false);
+        assertEq(actualShares, 0);
+        assertEq(actualRatio.numerator, token0AcquiredFromSwap);
+        assertEq(actualRatio.denominator, token1DustlessAmount);
+    }
 }

--- a/test/zap/staking/SimulateStakeDoubleSwap.t.sol
+++ b/test/zap/staking/SimulateStakeDoubleSwap.t.sol
@@ -105,4 +105,15 @@ contract SimulateStakeDoubleSwapTest is BaseSolidZapStaker {
         vm.expectRevert("invalid_swap");
         zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, swap2);
     }
+
+    function testSimulateStakeDoubleSwap_callsIUniProxyForCurrentRatio() public {
+        uint token0AcquiredFromSwap = 500;
+        uint token1AcquiredFromSwap = 600;
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, token0AcquiredFromSwap);
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, token1AcquiredFromSwap);
+
+        vm.prank(testAccount0);
+        _expectCall_getDepositAmount(address(hypervisor), address(token0), token0AcquiredFromSwap);
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, swap2);
+    }
 }

--- a/test/zap/staking/SimulateStakeDoubleSwap.t.sol
+++ b/test/zap/staking/SimulateStakeDoubleSwap.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+import "./BaseSolidZapStaker.t.sol";
+
+contract SimulateStakeDoubleSwapTest is BaseSolidZapStaker {
+    function testSimulateStakeDoubleSwap_transfersOverTheInputTokenAmount() public {
+        vm.prank(testAccount0);
+        _expectCall_ERC20_transferFrom(testAccount0, 1000);
+        zapStaker.simulateStakeDoubleSwap(
+            address(inputToken),
+            1000,
+            address(hypervisor),
+            emptySwap1,
+            emptySwap2
+        );
+    }
+
+    function testSimulateStakeDoubleSwap_approvesRouterToSpendInputToken() public {
+        vm.prank(testAccount0);
+        _expectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
+        zapStaker.simulateStakeDoubleSwap(
+            address(inputToken),
+            1000,
+            address(hypervisor),
+            emptySwap1,
+            emptySwap2
+        );
+
+        uint actual = inputToken.allowance(address(zapStaker), ROUTER);
+        assertEq(actual, type(uint).max);
+    }
+
+    function testSimulateStakeDoubleSwap_doesNotApproveRouterToSpendInputTokenIfAlreadyApproved() public {
+        vm.prank(address(zapStaker));
+        inputToken.approve(ROUTER, type(uint).max);
+
+        vm.prank(testAccount0);
+        _doNotExpectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
+        zapStaker.simulateStakeDoubleSwap(
+            address(inputToken),
+            1000,
+            address(hypervisor),
+            emptySwap1,
+            emptySwap2
+        );
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap1() public {
+        vm.prank(testAccount0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
+        zapStaker.simulateStakeDoubleSwap(
+            address(inputToken),
+            1000,
+            address(hypervisor),
+            emptySwap1,
+            emptySwap2
+        );
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason()
+        public
+    {
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
+
+        vm.prank(testAccount0);
+        _expectRevert_GenericSwapError();
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, emptySwap2);
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithProvidedReason() public {
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
+
+        vm.prank(testAccount0);
+        vm.expectRevert("invalid_swap");
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, emptySwap2);
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap2() public {
+        vm.prank(testAccount0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 0);
+        zapStaker.simulateStakeDoubleSwap(
+            address(inputToken),
+            1000,
+            address(hypervisor),
+            emptySwap1,
+            emptySwap2
+        );
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap2_revertsWithGenericErrorIfRouterGivesEmptyReason()
+        public
+    {
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
+
+        vm.prank(testAccount0);
+        _expectRevert_GenericSwapError();
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, swap2);
+    }
+
+    function testSimulateStakeDoubleSwap_executesSwap2_revertsWithProvidedReason() public {
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
+
+        vm.prank(testAccount0);
+        vm.expectRevert("invalid_swap");
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, swap2);
+    }
+}

--- a/test/zap/staking/StakeDoubleSwap.t.sol
+++ b/test/zap/staking/StakeDoubleSwap.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.18;
 
 import "./BaseSolidZapStaker.t.sol";
 
-contract SolidZapStakerTest is BaseSolidZapStaker {
+contract StakeDoubleSwapTest is BaseSolidZapStaker {
     function testSetsRouter() public {
         assertEq(zapStaker.router(), ROUTER);
     }

--- a/test/zap/staking/StakeDoubleSwap.t.sol
+++ b/test/zap/staking/StakeDoubleSwap.t.sol
@@ -8,6 +8,10 @@ contract StakeDoubleSwapTest is BaseSolidZapStaker {
         assertEq(zapStaker.router(), ROUTER);
     }
 
+    function testWETH() public {
+        assertEq(zapStaker.weth(), address(weth));
+    }
+
     function testSetsIUniProxy() public {
         assertEq(zapStaker.iUniProxy(), IUNIPROXY);
     }

--- a/test/zap/staking/StakeETH.t.sol
+++ b/test/zap/staking/StakeETH.t.sol
@@ -4,6 +4,10 @@ pragma solidity 0.8.18;
 import "./BaseSolidZapStaker.t.sol";
 
 contract StakeETHTest is BaseSolidZapStaker {
+    function testApprovesRouterToSpendWETH() public {
+        assertEq(weth.allowance(address(zapStaker), ROUTER), type(uint).max);
+    }
+
     function testStakeDoubleSwap_wrapsTheValueReceived() public {
         uint wethBalanceBefore = weth.balanceOf(address(zapStaker));
 

--- a/test/zap/staking/StakeETH.t.sol
+++ b/test/zap/staking/StakeETH.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.18;
+
+import "./BaseSolidZapStaker.t.sol";
+
+contract StakeETHTest is BaseSolidZapStaker {
+    function testStakeDoubleSwap_wrapsTheValueReceived() public {
+        uint wethBalanceBefore = weth.balanceOf(address(zapStaker));
+
+        hoax(testAccount0, 1 ether);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+
+        uint wethBalanceAfter = weth.balanceOf(address(zapStaker));
+        assertEq(wethBalanceAfter - wethBalanceBefore, 1000);
+        assertEq(testAccount0.balance, 1 ether - 1000);
+    }
+}

--- a/test/zap/staking/StakeETH.t.sol
+++ b/test/zap/staking/StakeETH.t.sol
@@ -8,7 +8,7 @@ contract StakeETHTest is BaseSolidZapStaker {
         assertEq(weth.allowance(address(zapStaker), ROUTER), type(uint).max);
     }
 
-    function testStakeDoubleSwap_wrapsTheValueReceived() public {
+    function testStakeETH_wrapsTheValueReceived() public {
         uint wethBalanceBefore = weth.balanceOf(address(zapStaker));
 
         hoax(testAccount0, 1 ether);
@@ -17,5 +17,181 @@ contract StakeETHTest is BaseSolidZapStaker {
         uint wethBalanceAfter = weth.balanceOf(address(zapStaker));
         assertEq(wethBalanceAfter - wethBalanceBefore, 1000);
         assertEq(testAccount0.balance, 1 ether - 1000);
+    }
+
+    function testStakeETH_executesSwap1() public {
+        hoax(testAccount0, 1 ether);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
+
+        hoax(testAccount0, 1 ether);
+        _expectRevert_GenericSwapError();
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_executesSwap1_revertsWithProvidedReason() public {
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
+
+        hoax(testAccount0, 1 ether);
+        vm.expectRevert("invalid_swap");
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_executesSwap2() public {
+        hoax(testAccount0, 1 ether);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_executesSwap2_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
+
+        hoax(testAccount0, 1 ether);
+        _expectRevert_GenericSwapError();
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2, 0);
+    }
+
+    function testStakeETH_executesSwap2_revertsWithProvidedReason() public {
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
+
+        hoax(testAccount0, 1 ether);
+        vm.expectRevert("invalid_swap");
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2, 0);
+    }
+
+    function testStakeETH_approvesHypervisorToSpendToken0() public {
+        hoax(testAccount0, 1 ether);
+        _expectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+
+        uint actual = token0.allowance(address(zapStaker), address(hypervisor));
+        assertEq(actual, type(uint).max);
+    }
+
+    function testStakeETH_doesNotApproveHypervisorToSpendToken0IfAlreadyApproved() public {
+        vm.prank(address(zapStaker));
+        token0.approve(address(hypervisor), type(uint).max);
+
+        hoax(testAccount0, 1 ether);
+        _doNotExpectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_approvesHypervisorToSpendToken1() public {
+        hoax(testAccount0, 1 ether);
+        _expectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+
+        uint actual = token1.allowance(address(zapStaker), address(hypervisor));
+        assertEq(actual, type(uint).max);
+    }
+
+    function testStakeETH_doesNotApproveHypervisorToSpendToken1IfAlreadyApproved() public {
+        vm.prank(address(zapStaker));
+        token1.approve(address(hypervisor), type(uint).max);
+
+        hoax(testAccount0, 1 ether);
+        _doNotExpectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_depositsViaIUniProxy_exactTokenAmountsAfterSwaps() public {
+        uint token0AcquiredFromSwap = 500;
+        uint token1AcquiredFromSwap = 600;
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, token0AcquiredFromSwap);
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, token1AcquiredFromSwap);
+        uint sharesMinted = 100;
+        uint token0BalanceBeforeSwap = 1000;
+        uint token1BalanceBeforeSwap = 1001;
+
+        _setBalancesBeforeSwap(token0BalanceBeforeSwap, token1BalanceBeforeSwap);
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        _expectCall_deposit(
+            token0AcquiredFromSwap,
+            token1AcquiredFromSwap,
+            address(zapStaker),
+            address(hypervisor),
+            _uniProxyMinIn()
+        );
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, swap2, 0);
+    }
+
+    function testStakeETH_depositsViaIUniProxy_revertsIfMintedSharesIsLessThanMin() public {
+        uint token0AcquiredFromSwap = 500;
+        uint token1AcquiredFromSwap = 600;
+        bytes memory swap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, token0AcquiredFromSwap);
+        bytes memory swap2 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, token1AcquiredFromSwap);
+        uint sharesMinted = 100;
+        uint minShares = sharesMinted + 1;
+        uint token0BalanceBeforeSwap = 1000;
+        uint token1BalanceBeforeSwap = 1001;
+
+        _setBalancesBeforeSwap(token0BalanceBeforeSwap, token1BalanceBeforeSwap);
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        _expectRevert_AcquiredSharesLessThanMin(sharesMinted, minShares);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, swap2, minShares);
+    }
+
+    function testStakeETH_approvesSolidStakingToSpendShares() public {
+        hoax(testAccount0, 1 ether);
+        _expectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+
+        uint actual = hypervisor.allowance(address(zapStaker), address(SOLIDSTAKING));
+        assertEq(actual, type(uint).max);
+    }
+
+    function testStakeETH_doesNotApproveSolidStakingToSpendSharesIfAlreadyApproved() public {
+        vm.prank(address(zapStaker));
+        hypervisor.approve(address(SOLIDSTAKING), type(uint).max);
+
+        hoax(testAccount0, 1 ether);
+        _doNotExpectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_stakesSharesWithRecipient() public {
+        uint sharesMinted = 1500;
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        _expectCall_stake(address(hypervisor), sharesMinted, testAccount0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+    }
+
+    function testStakeETH_stakesSharesWithSpecifiedRecipient() public {
+        uint sharesMinted = 1500;
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        _expectCall_stake(address(hypervisor), sharesMinted, testAccount1);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0, testAccount1);
+    }
+
+    function testStakeETH_returnsFinalStakedSharesAmount() public {
+        uint sharesMinted = 1500;
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        uint actual = zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+
+        assertEq(actual, sharesMinted);
+    }
+
+    function testStakeETH_emitsZapStakeEvent() public {
+        uint sharesMinted = 1500;
+
+        hoax(testAccount0, 1 ether);
+        _mockUniProxy_deposit(sharesMinted);
+        _expectEmit_ZapStake(testAccount0, address(weth), 1000, sharesMinted);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
     }
 }

--- a/test/zap/staking/WMATIC.sol
+++ b/test/zap/staking/WMATIC.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.16;
+
+contract WMATIC {
+    string public name = "Wrapped Matic";
+    string public symbol = "WMATIC";
+    uint8 public decimals = 18;
+
+    event Approval(address indexed src, address indexed guy, uint wad);
+    event Transfer(address indexed src, address indexed dst, uint wad);
+    event Deposit(address indexed dst, uint wad);
+    event Withdrawal(address indexed src, uint wad);
+
+    mapping(address => uint) public balanceOf;
+    mapping(address => mapping(address => uint)) public allowance;
+
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        (bool success, ) = payable(msg.sender).call{ value: wad }("");
+        require(success, "Failed to send Ether");
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        emit Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(
+        address src,
+        address dst,
+        uint wad
+    ) public returns (bool) {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #383 

*needs to be simulated from an account that actually holds input token amount, and the amount is approved to be spent by the zapStaker

1. inputs: input token address, input amount, hypervisor, swap1, swap2
2. transfer input token amount from msg.sender to this contract
3. if needed, zapStaker approves router to spend max input token amount
4. call router with encoded swap, capture success and retData. propagate error if swap failed
5. use _IUniProxy_ to check if the amount of tokens received from swap (balanceAfterSwap - balanceBeforeSwap) can be used to do a dustless deposit
   * this means calling getDepositAmount with token0 balance to obtain the range token1 balance needs to be in, and checking if token1 balance is within that range
6. if dustless deposit is possible
   * call deposit on _IUniProxy_ with the amount of tokens received from swap (balanceAfterSwap - balanceBeforeSwap) 
   * this returns the amount of shares minted to this contract
   * return:
     * dustless = true
     * shares   = shares minted from function
     * ratio    = (0, 0)
7. if dustless deposit is NOT possible
   * return:
     * dustless = false
     * shares   = 0
     * ratio    = ratio computed previously