### PR TITLE
Implement audit suggestions

### DIFF
--- a/contracts/interfaces/zap/ISolidZapStaker.sol
+++ b/contracts/interfaces/zap/ISolidZapStaker.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.18;
 /// @author Solid World
 interface ISolidZapStaker {
     error AcquiredSharesLessThanMin(uint acquired, uint min);
+    error InvalidSwap();
 
     event ZapStake(
         address indexed zapRecipient,

--- a/contracts/zap/collateralize/BaseSolidZapCollateralize.sol
+++ b/contracts/zap/collateralize/BaseSolidZapCollateralize.sol
@@ -69,7 +69,15 @@ abstract contract BaseSolidZapCollateralize is
         return interfaceId == 0x01ffc9a7 || interfaceId == 0x4e2312e0;
     }
 
-    receive() external payable {}
+    receive() external payable {
+        if (msg.sender != weth) {
+            revert ETHTransferFailed();
+        }
+    }
 
-    fallback() external payable {}
+    fallback() external payable {
+        if (msg.sender != weth) {
+            revert ETHTransferFailed();
+        }
+    }
 }

--- a/contracts/zap/collateralize/SolidZapCollateralize.sol
+++ b/contracts/zap/collateralize/SolidZapCollateralize.sol
@@ -35,7 +35,7 @@ contract SolidZapCollateralize is BaseSolidZapCollateralize {
         address dustRecipient
     ) external nonReentrant {
         _collateralizeToOutputToken(crispToken, batchId, amountIn, amountOutMin, swap);
-        uint outputAmount = _sweepTokensTo(outputToken, msg.sender);
+        uint outputAmount = _sweepTokensTo(outputToken, msg.sender, true);
         uint dust = _sweepTokensTo(crispToken, dustRecipient);
 
         _emitZapEvent(msg.sender, batchId, outputToken, outputAmount, dust, dustRecipient);
@@ -53,7 +53,7 @@ contract SolidZapCollateralize is BaseSolidZapCollateralize {
         address zapRecipient
     ) external nonReentrant {
         _collateralizeToOutputToken(crispToken, batchId, amountIn, amountOutMin, swap);
-        uint outputAmount = _sweepTokensTo(outputToken, zapRecipient);
+        uint outputAmount = _sweepTokensTo(outputToken, zapRecipient, true);
         uint dust = _sweepTokensTo(crispToken, dustRecipient);
 
         _emitZapEvent(zapRecipient, batchId, outputToken, outputAmount, dust, dustRecipient);
@@ -120,7 +120,7 @@ contract SolidZapCollateralize is BaseSolidZapCollateralize {
     function _sweepETHTo(address zapRecipient) private returns (uint sweptAmount) {
         sweptAmount = IERC20(weth).balanceOf(address(this));
         if (sweptAmount == 0) {
-            return 0;
+            revert SweepAmountZero();
         }
 
         IWETH(weth).withdraw(sweptAmount);

--- a/contracts/zap/staking/SolidZapStaker.sol
+++ b/contracts/zap/staking/SolidZapStaker.sol
@@ -246,6 +246,10 @@ contract SolidZapStaker is BaseSolidZapStaker {
             token1Address
         );
 
+        if (token0BalanceAfter <= token0BalanceBefore || token1BalanceAfter <= token1BalanceBefore) {
+            revert InvalidSwap();
+        }
+
         swapResults.token0._address = token0Address;
         swapResults.token0.balance = token0BalanceAfter - token0BalanceBefore;
 
@@ -277,6 +281,10 @@ contract SolidZapStaker is BaseSolidZapStaker {
             token0Address,
             token1Address
         );
+
+        if (token0BalanceAfter <= token0BalanceBefore || token1BalanceAfter <= token1BalanceBefore) {
+            revert InvalidSwap();
+        }
 
         swapResults.token0._address = token0Address;
         swapResults.token0.balance = token0BalanceAfter - token0BalanceBefore;

--- a/test/zap/collateralize/BaseSolidZapCollateralize.sol
+++ b/test/zap/collateralize/BaseSolidZapCollateralize.sol
@@ -23,7 +23,7 @@ abstract contract BaseSolidZapCollateralizeTest is BaseTest {
 
     address internal testAccount0;
     address internal testAccount1;
-    bytes internal emptySwap;
+    bytes internal basicSwap;
 
     ISolidZapCollateralize internal zap;
 
@@ -37,7 +37,7 @@ abstract contract BaseSolidZapCollateralizeTest is BaseTest {
     );
 
     function setUp() public {
-        emptySwap = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 0);
+        basicSwap = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 1);
 
         testAccount0 = vm.addr(3);
         testAccount1 = vm.addr(4);
@@ -120,6 +120,16 @@ abstract contract BaseSolidZapCollateralizeTest is BaseTest {
         returns (bytes memory)
     {
         return abi.encodeWithSignature("swap(uint256,uint256)", uint(behaviour), acquiredAmount);
+    }
+
+    function _prepareMinWethOutputAmount() internal returns (uint) {
+        return _prepareWethOutputAmount(1);
+    }
+
+    function _prepareWethOutputAmount(uint wethOutputAmount) internal returns (uint) {
+        vm.deal(address(weth), wethOutputAmount);
+        weth.mint(address(zap), wethOutputAmount);
+        return wethOutputAmount;
     }
 
     function _labelAccounts() private {

--- a/test/zap/collateralize/ZapCollateralize.t.sol
+++ b/test/zap/collateralize/ZapCollateralize.t.sol
@@ -15,7 +15,7 @@ contract ZapCollateralizeTest is BaseSolidZapCollateralizeTest {
             BATCH_ID,
             amountIn,
             0,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
 
@@ -35,7 +35,7 @@ contract ZapCollateralizeTest is BaseSolidZapCollateralizeTest {
             BATCH_ID,
             amountIn,
             amountOutMin,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
 
@@ -52,7 +52,7 @@ contract ZapCollateralizeTest is BaseSolidZapCollateralizeTest {
             BATCH_ID,
             0,
             0,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
 
@@ -72,21 +72,21 @@ contract ZapCollateralizeTest is BaseSolidZapCollateralizeTest {
             BATCH_ID,
             0,
             0,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
     }
 
     function testZapCollateralize_executesSwap() public {
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
         zap.zapCollateralize(
             address(outputToken),
             address(crispToken),
             BATCH_ID,
             0,
             0,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
     }
@@ -161,7 +161,7 @@ contract ZapCollateralizeTest is BaseSolidZapCollateralizeTest {
             BATCH_ID,
             amountIn,
             dust,
-            emptySwap,
+            basicSwap,
             testAccount1
         );
 

--- a/test/zap/decollateralize/BaseSolidZapDecollateralize.sol
+++ b/test/zap/decollateralize/BaseSolidZapDecollateralize.sol
@@ -22,7 +22,7 @@ abstract contract BaseSolidZapDecollateralizeTest is BaseTest {
 
     address internal testAccount0;
     address internal testAccount1;
-    bytes internal emptySwap;
+    bytes internal basicSwap;
 
     ISolidZapDecollateralize internal zap;
     ISolidZapDecollateralize.DecollateralizeParams internal emptyParams;
@@ -37,7 +37,7 @@ abstract contract BaseSolidZapDecollateralizeTest is BaseTest {
     );
 
     function setUp() public {
-        emptySwap = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 0);
+        basicSwap = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 1);
         emptyParams = ISolidZapDecollateralize.DecollateralizeParams({
             batchIds: _toArray(0),
             amountsIn: _toArray(0),

--- a/test/zap/decollateralize/ZapDecollateralize.t.sol
+++ b/test/zap/decollateralize/ZapDecollateralize.t.sol
@@ -11,7 +11,7 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );
@@ -24,7 +24,7 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );
@@ -43,7 +43,7 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );
@@ -51,12 +51,12 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
 
     function testZapDecollateralize_executesSwap() public {
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
         zap.zapDecollateralize(
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );
@@ -99,7 +99,7 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );
@@ -118,7 +118,7 @@ contract ZapDecollateralizeTest is BaseSolidZapDecollateralizeTest {
             address(inputToken),
             1000,
             address(crispToken),
-            emptySwap,
+            basicSwap,
             testAccount1,
             emptyParams
         );

--- a/test/zap/decollateralize/ZapDecollateralizeETH.t.sol
+++ b/test/zap/decollateralize/ZapDecollateralizeETH.t.sol
@@ -8,7 +8,7 @@ contract ZapDecollateralizeETHTest is BaseSolidZapDecollateralizeTest {
         uint wethBalanceBefore = weth.balanceOf(address(zap));
 
         hoax(testAccount0, 1 ether);
-        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), emptySwap, testAccount1, emptyParams);
+        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), basicSwap, testAccount1, emptyParams);
 
         uint wethBalanceAfter = weth.balanceOf(address(zap));
 
@@ -18,8 +18,8 @@ contract ZapDecollateralizeETHTest is BaseSolidZapDecollateralizeTest {
 
     function testZapDecollateralizeETH_executesSwap() public {
         hoax(testAccount0, 1 ether);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
-        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), emptySwap, testAccount1, emptyParams);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
+        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), basicSwap, testAccount1, emptyParams);
     }
 
     function testZapDecollateralizeETH_executesSwap_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -41,7 +41,7 @@ contract ZapDecollateralizeETHTest is BaseSolidZapDecollateralizeTest {
     function testZapDecollateralizeETH_approvesSWMToSpendCrispToken() public {
         hoax(testAccount0, 1 ether);
         _expectCall_ERC20_approve_maxUint(address(crispToken), SWM);
-        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), emptySwap, testAccount1, emptyParams);
+        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), basicSwap, testAccount1, emptyParams);
 
         uint actual = crispToken.allowance(address(zap), SWM);
         assertEq(actual, type(uint).max);
@@ -53,7 +53,7 @@ contract ZapDecollateralizeETHTest is BaseSolidZapDecollateralizeTest {
 
         hoax(testAccount0, 1 ether);
         _doNotExpectCall_ERC20_approve_maxUint(address(crispToken), SWM);
-        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), emptySwap, testAccount1, emptyParams);
+        zap.zapDecollateralizeETH{ value: 1000 }(address(crispToken), basicSwap, testAccount1, emptyParams);
     }
 
     function testZapDecollateralizeETH_decollateralizesTokens() public {

--- a/test/zap/staking/BaseSolidZapStaker.sol
+++ b/test/zap/staking/BaseSolidZapStaker.sol
@@ -25,8 +25,8 @@ abstract contract BaseSolidZapStakerTest is BaseTest {
     TestToken internal token1;
     WMATIC internal weth;
 
-    bytes internal emptySwap1;
-    bytes internal emptySwap2;
+    bytes internal basicSwap0;
+    bytes internal basicSwap1;
 
     ISolidZapStaker internal zapStaker;
 
@@ -38,8 +38,8 @@ abstract contract BaseSolidZapStakerTest is BaseTest {
     );
 
     function setUp() public {
-        emptySwap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 0);
-        emptySwap2 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, 0);
+        basicSwap0 = _encodeSwap(RouterBehaviour.MINTS_TOKEN0, 1);
+        basicSwap1 = _encodeSwap(RouterBehaviour.MINTS_TOKEN1, 1);
 
         IUNIPROXY = vm.addr(1);
         SOLIDSTAKING = vm.addr(2);

--- a/test/zap/staking/SimulateStakeDoubleSwap.t.sol
+++ b/test/zap/staking/SimulateStakeDoubleSwap.t.sol
@@ -11,8 +11,8 @@ contract SimulateStakeDoubleSwapTest is BaseSolidZapStakerTest {
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
-            emptySwap2
+            basicSwap0,
+            basicSwap1
         );
     }
 
@@ -23,8 +23,8 @@ contract SimulateStakeDoubleSwapTest is BaseSolidZapStakerTest {
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
-            emptySwap2
+            basicSwap0,
+            basicSwap1
         );
 
         uint actual = inputToken.allowance(address(zapStaker), ROUTER);
@@ -41,69 +41,69 @@ contract SimulateStakeDoubleSwapTest is BaseSolidZapStakerTest {
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
-            emptySwap2
+            basicSwap0,
+            basicSwap1
         );
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap1() public {
+    function testSimulateStakeDoubleSwap_executesSwap0() public {
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
         zapStaker.simulateStakeDoubleSwap(
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
-            emptySwap2
+            basicSwap0,
+            basicSwap1
         );
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason()
+    function testSimulateStakeDoubleSwap_executesSwap0_revertsWithGenericErrorIfRouterGivesEmptyReason()
         public
     {
         bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
 
         vm.prank(testAccount0);
         _expectRevert_GenericSwapError();
-        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, emptySwap2);
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, basicSwap1);
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithProvidedReason() public {
+    function testSimulateStakeDoubleSwap_executesSwap0_revertsWithProvidedReason() public {
         bytes memory swap1 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
 
         vm.prank(testAccount0);
         vm.expectRevert("invalid_swap");
-        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, emptySwap2);
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), swap1, basicSwap1);
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap2() public {
+    function testSimulateStakeDoubleSwap_executesSwap1() public {
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 1);
         zapStaker.simulateStakeDoubleSwap(
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
-            emptySwap2
+            basicSwap0,
+            basicSwap1
         );
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap2_revertsWithGenericErrorIfRouterGivesEmptyReason()
+    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason()
         public
     {
         bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_NO_REASON, 0);
 
         vm.prank(testAccount0);
         _expectRevert_GenericSwapError();
-        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, swap2);
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), basicSwap0, swap2);
     }
 
-    function testSimulateStakeDoubleSwap_executesSwap2_revertsWithProvidedReason() public {
+    function testSimulateStakeDoubleSwap_executesSwap1_revertsWithProvidedReason() public {
         bytes memory swap2 = _encodeSwap(RouterBehaviour.REVERTS_WITH_REASON, 0);
 
         vm.prank(testAccount0);
         vm.expectRevert("invalid_swap");
-        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, swap2);
+        zapStaker.simulateStakeDoubleSwap(address(inputToken), 1000, address(hypervisor), basicSwap0, swap2);
     }
 
     function testSimulateStakeDoubleSwap_callsIUniProxyForCurrentRatio() public {

--- a/test/zap/staking/SimulateStakeETH.t.sol
+++ b/test/zap/staking/SimulateStakeETH.t.sol
@@ -8,7 +8,7 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
         uint wethBalanceBefore = weth.balanceOf(address(zapStaker));
 
         hoax(testAccount0, 1 ether);
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1);
 
         uint wethBalanceAfter = weth.balanceOf(address(zapStaker));
         assertEq(wethBalanceAfter - wethBalanceBefore, 1000);
@@ -17,8 +17,8 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
 
     function testSimulateStakeETH_executesSwap1() public {
         hoax(testAccount0, 1 ether);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1);
     }
 
     function testSimulateStakeETH_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -26,7 +26,7 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _expectRevert_GenericSwapError();
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), swap1, basicSwap1);
     }
 
     function testSimulateStakeETH_executesSwap1_revertsWithProvidedReason() public {
@@ -34,13 +34,13 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         vm.expectRevert("invalid_swap");
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), swap1, basicSwap1);
     }
 
     function testSimulateStakeETH_executesSwap2() public {
         hoax(testAccount0, 1 ether);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 0);
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 1);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1);
     }
 
     function testSimulateStakeETH_executesSwap2_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -48,7 +48,7 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _expectRevert_GenericSwapError();
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), basicSwap0, swap2);
     }
 
     function testSimulateStakeETH_executesSwap2_revertsWithProvidedReason() public {
@@ -56,7 +56,7 @@ contract SimulateStakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         vm.expectRevert("invalid_swap");
-        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2);
+        zapStaker.simulateStakeETH{ value: 1000 }(address(hypervisor), basicSwap0, swap2);
     }
 
     function testSimulateStakeETH_callsIUniProxyForCurrentRatio() public {

--- a/test/zap/staking/SimulateStakeSingleSwap.t.sol
+++ b/test/zap/staking/SimulateStakeSingleSwap.t.sol
@@ -7,21 +7,21 @@ contract SimulateStakeSingleSwapTest is BaseSolidZapStakerTest {
     function testSimulateStakeSingleSwap_revertsIfInputTokenIsNotAHypervisorToken() public {
         vm.prank(testAccount0);
         _expectRevert_InvalidInput();
-        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1);
+        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap0);
     }
 
     function testSimulateStakeSingleSwap_transfersOverTheInputTokenAmount() public {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_transferFrom(testAccount0, 1000);
-        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1);
+        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1);
     }
 
     function testSimulateStakeSingleSwap_approvesRouterToSpendInputToken() public {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
-        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1);
+        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1);
 
         uint actual = inputToken.allowance(address(zapStaker), ROUTER);
         assertEq(actual, type(uint).max);
@@ -34,14 +34,14 @@ contract SimulateStakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _doNotExpectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
-        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1);
+        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1);
     }
 
     function testSimulateStakeSingleSwap_executesSwap() public {
         _overwriteToken0();
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
-        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 1);
+        zapStaker.simulateStakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1);
     }
 
     function testSimulateStakeSingleSwap_executesSwap_revertsWithGenericErrorIfRouterGivesEmptyReason()

--- a/test/zap/staking/StakeETH.t.sol
+++ b/test/zap/staking/StakeETH.t.sol
@@ -12,7 +12,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
         uint wethBalanceBefore = weth.balanceOf(address(zapStaker));
 
         hoax(testAccount0, 1 ether);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
 
         uint wethBalanceAfter = weth.balanceOf(address(zapStaker));
         assertEq(wethBalanceAfter - wethBalanceBefore, 1000);
@@ -21,8 +21,8 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
     function testStakeETH_executesSwap1() public {
         hoax(testAccount0, 1 ether);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 1);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_executesSwap1_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -30,7 +30,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _expectRevert_GenericSwapError();
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, basicSwap1, 0);
     }
 
     function testStakeETH_executesSwap1_revertsWithProvidedReason() public {
@@ -38,13 +38,13 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         vm.expectRevert("invalid_swap");
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), swap1, basicSwap1, 0);
     }
 
     function testStakeETH_executesSwap2() public {
         hoax(testAccount0, 1 ether);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 0);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 1);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_executesSwap2_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -52,7 +52,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _expectRevert_GenericSwapError();
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, swap2, 0);
     }
 
     function testStakeETH_executesSwap2_revertsWithProvidedReason() public {
@@ -60,13 +60,13 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         vm.expectRevert("invalid_swap");
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, swap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, swap2, 0);
     }
 
     function testStakeETH_approvesHypervisorToSpendToken0() public {
         hoax(testAccount0, 1 ether);
         _expectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
 
         uint actual = token0.allowance(address(zapStaker), address(hypervisor));
         assertEq(actual, type(uint).max);
@@ -78,13 +78,13 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _doNotExpectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_approvesHypervisorToSpendToken1() public {
         hoax(testAccount0, 1 ether);
         _expectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
 
         uint actual = token1.allowance(address(zapStaker), address(hypervisor));
         assertEq(actual, type(uint).max);
@@ -96,7 +96,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _doNotExpectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_depositsViaIUniProxy_exactTokenAmountsAfterSwaps() public {
@@ -143,7 +143,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
     function testStakeETH_approvesSolidStakingToSpendShares() public {
         hoax(testAccount0, 1 ether);
         _expectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
 
         uint actual = hypervisor.allowance(address(zapStaker), address(SOLIDSTAKING));
         assertEq(actual, type(uint).max);
@@ -155,7 +155,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _doNotExpectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_stakesSharesWithRecipient() public {
@@ -164,7 +164,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
         hoax(testAccount0, 1 ether);
         _mockUniProxy_deposit(sharesMinted);
         _expectCall_stake(address(hypervisor), sharesMinted, testAccount0);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 
     function testStakeETH_stakesSharesWithSpecifiedRecipient() public {
@@ -173,7 +173,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
         hoax(testAccount0, 1 ether);
         _mockUniProxy_deposit(sharesMinted);
         _expectCall_stake(address(hypervisor), sharesMinted, testAccount1);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0, testAccount1);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0, testAccount1);
     }
 
     function testStakeETH_returnsFinalStakedSharesAmount() public {
@@ -181,7 +181,7 @@ contract StakeETHTest is BaseSolidZapStakerTest {
 
         hoax(testAccount0, 1 ether);
         _mockUniProxy_deposit(sharesMinted);
-        uint actual = zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        uint actual = zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
 
         assertEq(actual, sharesMinted);
     }
@@ -192,6 +192,6 @@ contract StakeETHTest is BaseSolidZapStakerTest {
         hoax(testAccount0, 1 ether);
         _mockUniProxy_deposit(sharesMinted);
         _expectEmit_ZapStake(testAccount0, address(weth), 1000, sharesMinted);
-        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), emptySwap1, emptySwap2, 0);
+        zapStaker.stakeETH{ value: 1000 }(address(hypervisor), basicSwap0, basicSwap1, 0);
     }
 }

--- a/test/zap/staking/StakeSingleSwap.t.sol
+++ b/test/zap/staking/StakeSingleSwap.t.sol
@@ -7,21 +7,21 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
     function testStakeSingleSwap_revertsIfInputTokenIsNotAHypervisorToken() public {
         vm.prank(testAccount0);
         _expectRevert_InvalidInput();
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap0, 0);
     }
 
     function testStakeSingleSwap_transfersOverTheInputTokenAmount() public {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_transferFrom(testAccount0, 1000);
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_approvesRouterToSpendInputToken() public {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
 
         uint actual = inputToken.allowance(address(zapStaker), ROUTER);
         assertEq(actual, type(uint).max);
@@ -34,14 +34,14 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _doNotExpectCall_ERC20_approve_maxUint(address(inputToken), ROUTER);
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_executesSwap() public {
         _overwriteToken0();
         vm.prank(testAccount0);
-        _expectCall_swap(RouterBehaviour.MINTS_TOKEN0, 0);
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        _expectCall_swap(RouterBehaviour.MINTS_TOKEN1, 1);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_executesSwap_revertsWithGenericErrorIfRouterGivesEmptyReason() public {
@@ -67,7 +67,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _expectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
 
         uint actual = token0.allowance(address(zapStaker), address(hypervisor));
         assertEq(actual, type(uint).max);
@@ -80,14 +80,14 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _doNotExpectCall_ERC20_approve_maxUint(address(token0), address(hypervisor));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_approvesHypervisorToSpendToken1() public {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
 
         uint actual = token1.allowance(address(zapStaker), address(hypervisor));
         assertEq(actual, type(uint).max);
@@ -100,7 +100,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _doNotExpectCall_ERC20_approve_maxUint(address(token1), address(hypervisor));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_depositsViaIUniProxy_exactTokenAmountsAfterSwap() public {
@@ -141,7 +141,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
         _overwriteToken0();
         vm.prank(testAccount0);
         _expectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
 
         uint actual = hypervisor.allowance(address(zapStaker), address(SOLIDSTAKING));
         assertEq(actual, type(uint).max);
@@ -154,7 +154,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
 
         vm.prank(testAccount0);
         _doNotExpectCall_ERC20_approve_maxUint(address(hypervisor), address(SOLIDSTAKING));
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_stakesSharesWithRecipient() public {
@@ -164,7 +164,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
         vm.prank(testAccount0);
         _mockUniProxy_deposit(sharesMinted);
         _expectCall_stake(address(hypervisor), sharesMinted, testAccount0);
-        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), 1000, address(hypervisor), basicSwap1, 0);
     }
 
     function testStakeSingleSwap_stakesSharesWithSpecifiedRecipient() public {
@@ -178,7 +178,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
+            basicSwap1,
             0,
             testAccount1
         );
@@ -194,7 +194,7 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
             address(inputToken),
             1000,
             address(hypervisor),
-            emptySwap1,
+            basicSwap1,
             0
         );
 
@@ -209,6 +209,6 @@ contract StakeSingleSwapTest is BaseSolidZapStakerTest {
         vm.prank(testAccount0);
         _mockUniProxy_deposit(sharesMinted);
         _expectEmit_ZapStake(testAccount0, address(inputToken), inputAmount, sharesMinted);
-        zapStaker.stakeSingleSwap(address(inputToken), inputAmount, address(hypervisor), emptySwap1, 0);
+        zapStaker.stakeSingleSwap(address(inputToken), inputAmount, address(hypervisor), basicSwap1, 0);
     }
 }


### PR DESCRIPTION
Suggestions: 

* _sweepETHTo checks the balance of WETH and returns normally even if it zero even though it is called after a swap whose output token should be WETH. Requiring that the WETH balance (or its difference) is different from 0 would verify that the swap's calldata are correct and the output token is indeed WETH. The same could be enforced for other ERC20 tokens, which are used as outputs.
* SolidZapStake _singleSwap and _doubleSwap do not require that the swapResults balances are different from 0.
